### PR TITLE
Allow configuring Data Processing Options in facebook-pixel

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ Writing your own adapters for currently unsupported analytics services is easy t
 1. `Facebook Pixel`
 
     - `id`: [ID](https://www.facebook.com/ads/manager/pixel/facebook_pixel/?act=129849836&pid=p1)
+    - dataProcessingOptions: _optional_ An object defining the method, country and state for [data processing options](https://developers.facebook.com/docs/marketing-apis/data-processing-options/)
+    ```js
+    dataProcessingOptions: {
+      method: ['LDU'],
+      country: 1,
+      state: 1000
+    }
+    ```
 
 #### Community adapters
 
@@ -124,7 +132,12 @@ module.exports = function(environment) {
         name: 'FacebookPixel',
         environments: ['production'],
         config: {
-          id: '1234567890'
+          id: '1234567890',
+          dataProcessingOptions: {
+            method: ['LDU'],
+            country: 1,
+            state: 1000
+          }
         }
       },
 

--- a/addon/metrics-adapters/facebook-pixel.js
+++ b/addon/metrics-adapters/facebook-pixel.js
@@ -11,7 +11,7 @@ export default BaseAdapter.extend({
   },
 
   init() {
-    const { id } = this.config;
+    const { id, dataProcessingOptions } = this.config;
 
     assert(`[ember-metrics] You must pass a valid \`id\` to the ${this.toString()} adapter`, id);
 
@@ -26,6 +26,11 @@ export default BaseAdapter.extend({
     t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
     document,'script','https://connect.facebook.net/en_US/fbevents.js');
     /* eslint-enable */
+
+    if (dataProcessingOptions) {
+      const { method, country, state } = dataProcessingOptions;
+      window.fbq('dataProcessingOptions', method, country, state);
+    }
 
     window.fbq('init', id);
 

--- a/tests/unit/metrics-adapters/facebook-pixel-test.js
+++ b/tests/unit/metrics-adapters/facebook-pixel-test.js
@@ -11,7 +11,12 @@ module('facebook-pixel adapter', function(hooks) {
 
   hooks.beforeEach(function() {
     config = {
-      id: '1234567890'
+      id: '1234567890',
+      dataProcessingOptions: {
+        method: ['LDU'],
+        country: 1,
+        state: 1000,
+      }
     };
 
     subject = this.owner.factoryFor('ember-metrics@metrics-adapter:facebook-pixel').create({ config });
@@ -57,5 +62,13 @@ module('facebook-pixel adapter', function(hooks) {
   test('#trackPage calls `fbq.track` with the right arguments', function(assert) {
     subject.trackPage({ page: '/my-page', title: 'My Title' });
     assert.ok(fbq.calledWith('track', 'PageView', { page: '/my-page', title: 'My Title' }), 'it sends the correct arguments and options');
+  });
+
+  test("#init calls `fbq` with dataProcessingOptions", function(assert) {
+    let { dataProcessingOptions, dataProcessingCountry, dataProcessingState } = fbq.instance.pluginConfig._configStore.dataProcessingOptions.global;
+
+    assert.ok((dataProcessingOptions == 'LDU'), 'it sends the correct Data Processing Options');
+    assert.ok((dataProcessingCountry == 1), 'it sends the correct Data Processing Country');
+    assert.ok((dataProcessingState == 1000), 'it sends the correct Data Processing State');
   });
 });


### PR DESCRIPTION
Facebook released a Limitited Data Use feature, to aid with CCPA
compliance. This commit allows enabling (or disabling) the LDU via
configuration.